### PR TITLE
build: remove dbg info, reduce size

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,13 +18,13 @@ jobs:
 
       - run: go test ./...
 
-      - run: go build -o gowebdav_linux_amd64 .
-      - run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o gowebdav_windows_amd64.exe .
-      - run: CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o gowebdav_darwin_amd64 .
+      - run: go build -ldflags "-s -w" -o gowebdav_linux_amd64 .
+      - run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o gowebdav_windows_amd64.exe .
+      - run: CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o gowebdav_darwin_amd64 .
 
-      - run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o gowebdav_linux_arm64 .
-      - run: CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -o gowebdav_windows_arm64.exe .
-      - run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o gowebdav_darwin_arm64 .
+      - run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w" -o gowebdav_linux_arm64 .
+      - run: CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -ldflags "-s -w" -o gowebdav_windows_arm64.exe .
+      - run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w" -o gowebdav_darwin_arm64 .
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
I've always used `-ldflags "-s -w"` for my projects since it almost halves the size. I can confirm that this works successfully on linux_amd64 . I doubt that it will not work on other platforms.
Test release: https://github.com/Jipok/GoWebDAV/releases/tag/test2
Build logs: https://github.com/Jipok/GoWebDAV/actions/runs/8019379209/job/21907122045