### PR TITLE
build(go): 升级 Go 版本至 1.25.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,20 +9,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/actions/checkout
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
+      # https://github.com/docker/login-action
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -30,7 +32,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             117503445/go_webdav
@@ -46,7 +48,7 @@ jobs:
 
       # https://github.com/docker/build-push-action
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       # https://github.com/actions/setup-go
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.25"
 
       - run: CGO_ENABLED=0 go test ./...
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS build
+FROM golang:1.25.1 AS build
 ARG GOPROXY=https://proxy.golang.org,direct
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/117503445/GoWebDAV
 
-go 1.23.4
+go 1.25.1
 
 require (
 	github.com/117503445/goutils v0.0.0-20240817175023-c208c6d669ae


### PR DESCRIPTION
将项目中的 Go 版本从 1.23 升级至 1.25.1，包括 GitHub Actions 工作流和 Dockerfile 中的配置。